### PR TITLE
Fix book lookup for punctuation-heavy queries

### DIFF
--- a/src/__tests__/findBook.test.ts
+++ b/src/__tests__/findBook.test.ts
@@ -58,6 +58,12 @@ describe('findBook', () => {
     expect(findBook('römer', 'X')).toEqual(expect.objectContaining({ id: 45 }));
   });
 
+  test('ignores punctuation characters', () => {
+    expect(findBook('ps/', 'E')).toEqual(expect.objectContaining({ id: 19 }));
+    expect(findBook('ps\\', 'E')).toEqual(expect.objectContaining({ id: 19 }));
+    expect(findBook('ps.', 'E')).toEqual(expect.objectContaining({ id: 19 }));
+  });
+
   test('throws error for unknown books', () => {
     expect(() => findBook('nonexistent', 'X')).toThrow('errors.bookNotFound');
     expect(() => findBook('', 'X')).toThrow('errors.bookNotFound');

--- a/src/utils/findBook.ts
+++ b/src/utils/findBook.ts
@@ -2,28 +2,28 @@ import { getBibleBooks } from '@/bibleBooks';
 import type { BibleBook, Language } from '@/types';
 
 export const findBook = (bookQuery: string, language: Language): BibleBook | BibleBook[] => {
-  const trimmedQuerry = bookQuery
+  const trimmedQuery = bookQuery
     .toLowerCase()
-    .replace(/[/.\s]/g, '')
+    .replace(/[\/.\s\\]/g, '')
     .trim();
 
-  if (!trimmedQuerry) {
-    console.error('Book query is empty', { bookQuery, trimmedQuerry });
+  if (!trimmedQuery) {
+    console.error('Book query is empty', { bookQuery, trimmedQuery });
     throw new Error('errors.bookNotFound');
   }
 
   const bibleBooks = getBibleBooks(language);
 
   if (!bibleBooks) {
-    console.error('No bible books found', { bookQuery, trimmedQuerry });
+    console.error('No bible books found', { bookQuery, trimmedQuery });
     throw new Error('errors.bookNotFound');
   }
 
   const bookEntries = bibleBooks
-    .filter((book) => (!book.prefix ? true : trimmedQuerry.match(/^[1-5]/)))
+    .filter((book) => (!book.prefix ? true : trimmedQuery.match(/^[1-5]/)))
     .filter((book) => {
       const alias = book.aliases.map((alias) => (book.prefix ? `${book.prefix}${alias}` : alias));
-      return alias.some((alias) => alias.startsWith(trimmedQuerry));
+      return alias.some((alias) => alias.startsWith(trimmedQuery));
     })
     .map((book) => ({ ...book, idPadded: book.id.toString().padStart(2, '0') }));
 


### PR DESCRIPTION
## Summary
- strip slashes, dots, whitespace and backslashes from book queries
- add regression test for punctuation handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e043cde8483219d5272f18f321571